### PR TITLE
chore(ci): prevent duplicate ci triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -45,11 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
-         docker run --rm --user "$(id -u)":"$(id -g)" -v $(pwd):/workspace -w /workspace -t -e TZ=UTC -e NO_IP6=1 pactfoundation/rust-musl-build ./scripts/ci-musl-build.sh
+          docker run --rm --user "$(id -u)":"$(id -g)" -v $(pwd):/workspace -w /workspace -t -e TZ=UTC -e NO_IP6=1 pactfoundation/rust-musl-build ./scripts/ci-musl-build.sh
 
   check-features:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: cargo check --no-default-features
-         


### PR DESCRIPTION
Triggering on all 'push' and 'pull_request' events will result in duplicated CI runs in PRs (due to both conditions being met).

Instead, trigger only on pushes to `master`, or updates to PRs targetting `master`.